### PR TITLE
修复图像搜索模块

### DIFF
--- a/ModuleCollection/ImageModule.cs
+++ b/ModuleCollection/ImageModule.cs
@@ -124,7 +124,7 @@ not_found:
         _query["pn"] = pn.ToString();
         _sw.Stop();
         _lastDownloadTime = _sw.Elapsed.ToMsString();
-        return _client.GetAsync($"{_url}?{_query}").Result.ToString();
+        return _client.GetAsync($"{_url}?{_query}").Result.Content.ReadAsStringAsync().Result;
     }
 
     private class JResult { public int listNum; public JImage[] data; }


### PR DESCRIPTION
旧版本错误地直接在对象上使用ToString()导致json解析失败