### PR TITLE
修复JSON内容的MIME类型

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ bld/
 
 # Visual Studio 2017 auto generated files
 Generated\ Files/
+launchSettings.json
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/ModuleCollection/ChatXiaoIceModule.cs
+++ b/ModuleCollection/ChatXiaoIceModule.cs
@@ -77,7 +77,7 @@ public class ChatXiaoIceModule : SingleTypeModule<MessagePlain>
         string normalizedQuery = AesEncrypt(msg.Text, _password, _bitLength);
         //JChatterBotRequest requestObj = new(_conversationId, new JQuery(normalizedQuery), _traceId);
         string s = "{\"conversationId\":\"" + _conversationId + "\",\"query\":{\"NormalizedQuery\":\"" + normalizedQuery + "\"},\"from\":\"chatbox\",\"traceId\":\"" + _traceId + "\",\"zoIsGCSResponse\":\"true\"}";
-        StringContent jsonAsPlainText = new(s);
+        StringContent jsonAsPlainText = new(s, Encoding.UTF8, "application/json");
         using (jsonAsPlainText)
         {
             HttpRequestMessage request = new();

--- a/klbot/Properties/launchSettings.json
+++ b/klbot/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "klbot": {
-      "commandName": "Project",
-      "commandLineArgs": "http://100.123.10.200:8080"
-    }
-  }
-}

--- a/klbot/Properties/launchSettings.json
+++ b/klbot/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "klbot": {
       "commandName": "Project",
-      "commandLineArgs": "http://mp:3356"
+      "commandLineArgs": "http://100.123.10.200:8080"
     }
   }
 }

--- a/klbotlib/JsonHelper.cs
+++ b/klbotlib/JsonHelper.cs
@@ -1,11 +1,16 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Web;
 
 namespace klbotlib.Json
 {
     static class JsonHelper
     {
+        internal static MediaTypeHeaderValue JsonMime { get; } = MediaTypeHeaderValue.Parse("application/json");
+        internal static StringContent CreateAsJson(string s)
+            => new StringContent(s, JsonMime);
         internal static class JsonSettings
         {
             //用于文件存储的Json序列化配置

--- a/klbotlib/MessageServer/Mirai/MiraiNetworkHelper.cs
+++ b/klbotlib/MessageServer/Mirai/MiraiNetworkHelper.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using klbotlib.Exceptions;
+using klbotlib.Json;
 using klbotlib.MessageServer.Mirai.JsonPrototypes;
 using Newtonsoft.Json;
 
@@ -52,15 +53,23 @@ internal static class MiraiNetworkHelper
     internal static async Task<string> Verify(string serverUrl, string key)
     {
         if (_verifyRequestBody == null)
-            _verifyRequestBody = new StringContent("{\"verifyKey\":\"" + key + "\"}");
-        HttpResponseMessage response = await _client.PostAsync(GetVerifyUrl(serverUrl), _verifyRequestBody);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync();
+            _verifyRequestBody = JsonHelper.CreateAsJson("{\"verifyKey\":\"" + key + "\"}");
+        try
+        {
+            HttpResponseMessage response = await _client.PostAsync(GetVerifyUrl(serverUrl), _verifyRequestBody);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsStringAsync();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+            return "failed";
+        }
     }
     //禁言
     internal static async Task<string> Mute(string serverUrl, long userId, long groupId, uint durationSeconds)
     {
-        StringContent content = new($"{{\"target\":{groupId},\"memberId\":{userId},\"time\":{durationSeconds}}}");
+        StringContent content = JsonHelper.CreateAsJson($"{{\"target\":{groupId},\"memberId\":{userId},\"time\":{durationSeconds}}}");
         HttpResponseMessage response = await _client.PostAsync(GetMuteUrl(serverUrl), content);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsStringAsync();
@@ -68,7 +77,7 @@ internal static class MiraiNetworkHelper
     //解除禁言
     internal static async Task<string> Unmute(string serverUrl, long userId, long groupId)
     {
-        StringContent content = new($"{{\"target\":{groupId},\"memberId\":{userId}}}");
+        StringContent content = JsonHelper.CreateAsJson($"{{\"target\":{groupId},\"memberId\":{userId}}}");
         HttpResponseMessage response = await _client.PostAsync(GetUnmuteUrl(serverUrl), content);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsStringAsync();

--- a/klbotlib/MessageServer/Mirai/MiraiNetworkHelper.cs
+++ b/klbotlib/MessageServer/Mirai/MiraiNetworkHelper.cs
@@ -92,8 +92,8 @@ internal static class MiraiNetworkHelper
     //尝试发送消息
     internal static async Task TrySendMessage(string serverUrl, MessageContext context, string fullMsgJson)
     {
-        string url = MiraiNetworkHelper.GetSendMessageUrl(serverUrl, context);
-        StringContent content = new StringContent(fullMsgJson, Encoding.UTF8);
+        string url = GetSendMessageUrl(serverUrl, context);
+        StringContent content = JsonHelper.CreateAsJson(fullMsgJson);
         HttpResponseMessage response = await _client.PostAsync(url, content);
         response.EnsureSuccessStatusCode();
         bool result = response.IsSuccessStatusCode;

--- a/klbotlib/MessageServer/Mirai/MiraiNetworkHelper.cs
+++ b/klbotlib/MessageServer/Mirai/MiraiNetworkHelper.cs
@@ -54,17 +54,9 @@ internal static class MiraiNetworkHelper
     {
         if (_verifyRequestBody == null)
             _verifyRequestBody = JsonHelper.CreateAsJson("{\"verifyKey\":\"" + key + "\"}");
-        try
-        {
-            HttpResponseMessage response = await _client.PostAsync(GetVerifyUrl(serverUrl), _verifyRequestBody);
-            response.EnsureSuccessStatusCode();
-            return await response.Content.ReadAsStringAsync();
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(ex.Message);
-            return "failed";
-        }
+        HttpResponseMessage response = await _client.PostAsync(GetVerifyUrl(serverUrl), _verifyRequestBody);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync();
     }
     //禁言
     internal static async Task<string> Mute(string serverUrl, long userId, long groupId, uint durationSeconds)

--- a/klbotlib/ModuleUtils.cs
+++ b/klbotlib/ModuleUtils.cs
@@ -101,9 +101,10 @@ namespace klbotlib.Modules.ModuleUtils
         /// </summary>
         /// <param name="url">地址</param>
         /// <param name="body">内容</param>
-        public async Task<string> PostStringAsync(string url, string body)
+        /// <param name="mime">MIME类型，默认为JSON</param>
+        public async Task<string> PostStringAsync(string url, string body, string mime = "application/json")
         {
-            StringContent content = new(body, Encoding.GetEncoding(ContentEncoding));
+            StringContent content = new(body, Encoding.GetEncoding(ContentEncoding), mime);
             return await InnerClient.PostAsync(url, content, _cancellationToken).Result.Content.ReadAsStringAsync();
         }
         /// <summary>


### PR DESCRIPTION
旧版本的mirai HTTP API插件没管MIME，所以之前为了偷懒，直接用默认的`StringContent`捏了JSON的payload，这样会导致MIME类型为`plain/text`或者之类的东西（没特意去看过，总之不是`application/json`）。

最新版本的插件增加了这部分校验，现在（至少`POST /verify`接口）如果用的MIME类型不对，服务器会报告错误。