### PR TITLE
修复单元测试StatusAutoSaveForAllModuleWhenCoreModuleProcessed。单元测试现在可全部通过

### DIFF
--- a/KLBotUnitTest/TestStatusAutoSave.cs
+++ b/KLBotUnitTest/TestStatusAutoSave.cs
@@ -23,7 +23,7 @@ public class TestStatusAutoSave
         bot.AddModule(module).Wait();
         bool initState = module.Enabled;
         //通过命令模块修改启用状态
-        MessagePlain msg = new(MessageContext.Group, -1, -1, "##switch FuckModule"); //unit_test_config.json中应将-1设置为监听群
+        MessagePlain msg = new(MessageContext.Group, -1, TestConst.TargetGroupId, "##switch FuckModule"); //unit_test_config.json中应将-1设置为监听群
         driver.AddReceivedMessage(msg);
         Assert.AreEqual(!initState, module.Enabled, "FuckModule.Enabled should have changed");
         //Test save file


### PR DESCRIPTION
单元测试失败原因：监听群ID发生修改，而测试用群ID未同步修改