### PR TITLE
状态自动保存单元测试修复

### DIFF
--- a/KLBotUnitTest/TestStatusAutoSave.cs
+++ b/KLBotUnitTest/TestStatusAutoSave.cs
@@ -36,6 +36,10 @@ public class TestStatusAutoSave
             continue;
         Assert.AreEqual(!initState, module.Enabled, "FuckModule.Enabled should have changed");
         // Test save file
+        // 内部WriteAllText()会导致文件短时间内处于长度=0状态，需等待文件完成写入
+        Console.WriteLine("Waiting for file to be saved");
+        while (new FileInfo(savePath).Length == 0)
+            continue;
         JsonNode? node = JsonSerializer.Deserialize<JsonNode>(File.ReadAllText(savePath));
         if (node == null)
             throw new JsonException($"Failed to deserialize {savePath} (1st)");
@@ -51,6 +55,10 @@ public class TestStatusAutoSave
             continue;
         Assert.AreEqual(initState, module.Enabled, "FuckModule.Enabled should have changed (2nd)");
         // Test save file
+        // 内部WriteAllText()会导致文件短时间内处于长度=0状态，需等待文件完成写入
+        Console.WriteLine("Waiting for file to be saved");
+        while (new FileInfo(savePath).Length == 0)
+            continue;
         node = JsonSerializer.Deserialize<JsonNode>(File.ReadAllText(savePath));
         if (node == null)
             throw new JsonException($"Failed to deserialize {savePath} (2nd)");

--- a/klbotlib/Modules/Module.cs
+++ b/klbotlib/Modules/Module.cs
@@ -338,7 +338,8 @@ namespace klbotlib.Modules
                 using var _ = new StreamWriter(File.Create(filePath));
             }
             await File.WriteAllTextAsync(filePath, json);
-            ModuleLog($"模块已保存至存档\"{filePath}\"");
+            if (printInfo)
+                ModuleLog($"模块已保存至存档\"{filePath}\"");
         }
 
         //helper 
@@ -398,7 +399,7 @@ namespace klbotlib.Modules
                     ModuleLog("任务结束, 无回复内容.");
                 //判断模块是否是核心模块。在核心模块的情况下，需要保存全部模块的状态，因为核心模块具有修改其他模块的状态的能力；
                 if (GetType().Assembly.Equals(typeof(KLBot).Assembly))
-                    _hostBot.ModuleChain.ForEach( async x => await x.SaveModuleStatus(true));
+                    _hostBot.ModuleChain.ForEach( async x => await x.SaveModuleStatus(false));
                 //否则可以假设模块只修改自身 所以只需保存自己
                 else
                     await SaveModuleStatus(false);


### PR DESCRIPTION
事件处理异步化之后，事件返回前不再等待保存完成。由于内部`WriteAllTextAsync()`会导致文件短时间内处于长度=0状态，需等待文件完成写入，否则可能读入空存档文件。